### PR TITLE
Replace _exit(0) with pthread_exit(0)

### DIFF
--- a/Android/Level2/app/src/main/cpp/foo.cpp
+++ b/Android/Level2/app/src/main/cpp/foo.cpp
@@ -24,7 +24,7 @@ void *monitor_pid(void *) {
 
         // If this is a release build, the child will segfault (status 11). Otherwise, waitpid() should never return.
 
-        _exit(0); // Commit seppuku
+        pthread_exit(0); // Commit seppuku
     }
 
     pthread_exit(NULL);


### PR DESCRIPTION
I found why the Level2 app crashing on Oreo, It looks like there is some issue with the _exit() call. I replaced it with pthread_exit() but I'm not sure if it has the same result as _exit(0). 

*_exit(0) crashes the app on Oreo. Probably some issue with the changes done in the oreo native runtime